### PR TITLE
Adding a README.md file to the example 07

### DIFF
--- a/examples/07_todolist/README.md
+++ b/examples/07_todolist/README.md
@@ -1,0 +1,21 @@
+# To Do List example
+
+## How to use
+
+### Live Example
+
+Checkout the [example on codesandbox](https://codesandbox.io/s/github/dai-shi/react-tracked/tree/master/examples/07_todolist).
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/dai-shi/react-tracked/tar.gz/master | tar -xz --strip=2 react-tracked-master/examples/07_todolist
+cd 07_todolist
+yarn && yarn run start
+```
+
+## The idea behind the example
+
+This is the complete source code of a simple todo app based on [Redux Todo App example](https://redux.js.org/basics/example).


### PR DESCRIPTION
Here is a small addition to improve the discoverability of the examples.\
\
Follows the content structure from the [next.js examples readme.md](https://github.com/zeit/next.js/tree/canary/examples/basic-export).

