### PR TITLE
prefer-create-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Prefer createContainer to default context
 
 ## [0.5.0] - 2019-07-13
 ### Changed

--- a/README.md
+++ b/README.md
@@ -110,14 +110,29 @@ if a value is changed. To avoid this, this libraries use undocumented
 feature of `calculateChangedBits`. It then uses a subscription model
 to force update when a component needs to re-render.
 
-## API
+## API (container)
+
+### createContainer
+
+```javascript
+import { createContainer } from 'react-tracked';
+
+const useValue = () => useReducer(...); // any custom hook that returns a tuple
+
+const {
+  Provider,
+  useDispatch,
+  useSelector,
+  useTrackedState,
+  useTracked,
+} = createContainer(useValue);
+```
 
 ### Provider
 
 ```javascript
-const useValue = () => useReducer(...); // any custom hook that returns a tuple
 const App = () => (
-  <Provider useValue={useValue}>
+  <Provider>
     ...
   </Provider>
 );
@@ -158,16 +173,65 @@ const Component = () => {
   // ...
 };
 ```
-### createContainer
+
+## API (default context)
+
+### Provider
 
 ```javascript
-const {
-  Provider,
-  useDispatch,
-  useSelector,
-  useTrackedState,
-  useTracked,
-} = createContainer(useValue); // create all APIs bound with new context
+import { Provider } from 'react-tracked';
+
+const useValue = () => useReducer(...); // any custom hook that returns a tuple
+
+const App = () => (
+  <Provider useValue={useValue}>
+    ...
+  </Provider>
+);
+```
+
+### useDispatch
+
+```javascript
+import { useDispatch } from 'react-tracked';
+
+const Component = () => {
+  const dispatch = useDispatch(); // simply to get the second one of the tuple
+  // ...
+};
+```
+
+### useSelector
+
+```javascript
+import { useSelector } from 'react-tracked';
+
+const Component = () => {
+  const selected = useSelector(selector); // same API in react-redux
+  // ...
+};
+```
+
+### useTrackedState
+
+```javascript
+import { useTrackedState } from 'react-tracked';
+
+const Component = () => {
+  const state = useTrackedState(); // same API in reactive-react-redux
+  // ...
+};
+```
+
+### useTracked
+
+```javascript
+import { useTracked } from 'react-tracked';
+
+const Component = () => {
+  const [state, dispatch] = useTracked(); // combination of useTrackedState and useDispatch
+  // ...
+};
 ```
 
 ## Examples

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -38,14 +38,19 @@ export const defaultContext = createCustomContext();
 // provider
 // -------------------------------------------------------
 
-export const Provider = ({
+export const createProvider = (customContext, customUseValue) => ({
   useValue,
-  customContext = defaultContext,
   children,
 }) => {
-  const useValueRef = useRef(useValue);
-  if (useValueRef.current !== useValue) {
-    throw new Error('useValue must be statically defined');
+  if (customUseValue) {
+    useValue = customUseValue;
+  } else {
+    // Although this looks like violating the hooks rule,
+    // it is ok because it won't change once created.
+    const useValueRef = useRef(useValue);
+    if (useValueRef.current !== useValue) {
+      throw new Error('useValue must be statically defined');
+    }
   }
   const [state, dispatch] = useValue();
   const listeners = useRef([]);
@@ -66,3 +71,5 @@ export const Provider = ({
     children,
   );
 };
+
+export const Provider = createProvider(defaultContext);

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1,21 +1,15 @@
-import { createElement } from 'react';
-
-import { Provider, createCustomContext } from './Provider';
-import { useTrackedState, useTracked } from './useTrackedState';
-import { useDispatch } from './useDispatch';
-import { useSelector } from './useSelector';
+import { createProvider, createCustomContext } from './Provider';
+import { createUseTrackedState, createUseTracked } from './useTrackedState';
+import { createUseDispatch } from './useDispatch';
+import { createUseSelector } from './useSelector';
 
 export const createContainer = (useValue) => {
   const customContext = createCustomContext();
   return {
-    Provider: ({ children }) => createElement(
-      Provider,
-      { useValue, customContext },
-      children,
-    ),
-    useTrackedState: () => useTrackedState({ customContext }),
-    useTracked: () => useTracked({ customContext }),
-    useDispatch: () => useDispatch({ customContext }),
-    useSelector: (selector, equalityFn) => useSelector(selector, { equalityFn, customContext }),
+    Provider: createProvider(customContext, useValue),
+    useTrackedState: createUseTrackedState(customContext),
+    useTracked: createUseTracked(customContext),
+    useDispatch: createUseDispatch(customContext),
+    useSelector: createUseSelector(customContext),
   };
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,42 +1,25 @@
 import * as React from 'react';
 
-type CustomContext = React.Context<unknown>;
+type EqlFn<V> = (a: V, b: V) => boolean;
 
-export type createCustomContext = () => CustomContext;
-
-export type ProviderProps<S, D> = {
-  useValue: () => [S, D];
-  customContext?: CustomContext;
-};
-
-export type ProviderType<S = unknown, D = unknown>
-  = React.ComponentType<ProviderProps<S, D>>;
-
-export const Provider: ProviderType;
-
-type Opts = {
-  customContext?: CustomContext;
-};
-
-export const useTrackedState: <S>(opts?: Opts) => S;
-
-export const useTracked: <S, D>(opts?: Opts) => [S, D];
-
-export const useDispatch: <D>(opts?: Opts) => D;
-
-export const useSelector: <S, V>(
-  selector: (state: S) => V,
-  equalityFn?: (a: V, b: V) => boolean | Opts & { equalityFn?: (a: V, b: V) => boolean },
-  opts?: Opts,
-) => V;
+// container
 
 export const createContainer: <S, D>(useValue: () => [S, D]) => {
   Provider: React.ComponentType;
   useTrackedState: () => S;
   useTracked: () => [S, D];
   useDispatch: () => D;
-  useSelector: <V>(
-    selector: (state: S) => V,
-    equalityFn?: (a: V, b: V) => boolean,
-  ) => V;
+  useSelector: <V>(selector: (state: S) => V, equalityFn?: EqlFn<V>) => V;
 };
+
+// default context
+
+export type ProviderType<S = unknown, D = unknown> = React.ComponentType<{
+  useValue: () => [S, D];
+}>;
+
+export const Provider: ProviderType;
+export const useTrackedState: <S>() => S;
+export const useTracked: <S, D>() => [S, D];
+export const useDispatch: <D>() => D;
+export const useSelector: <S, V>(selector: (state: S) => V, equalityFn?: EqlFn<V>) => V;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-export { Provider, createCustomContext } from './Provider';
+export { createContainer } from './createContainer';
+
+export { Provider } from './Provider';
 export { useTrackedState, useTracked } from './useTrackedState';
 export { useDispatch } from './useDispatch';
 export { useSelector } from './useSelector';
-export { createContainer } from './createContainer';

--- a/src/useDispatch.js
+++ b/src/useDispatch.js
@@ -2,10 +2,9 @@ import { useContext } from 'react';
 
 import { defaultContext } from './Provider';
 
-export const useDispatch = (opts = {}) => {
-  const {
-    customContext = defaultContext,
-  } = opts;
+export const createUseDispatch = customContext => () => {
   const { dispatch } = useContext(customContext);
   return dispatch;
 };
+
+export const useDispatch = createUseDispatch(defaultContext);

--- a/src/useSelector.js
+++ b/src/useSelector.js
@@ -8,14 +8,12 @@ import { defaultContext } from './Provider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
-const isFunction = f => typeof f === 'function';
 const defaultEqualityFn = (a, b) => a === b;
 
-export const useSelector = (selector, eqlFn, opts) => {
-  const {
-    equalityFn = isFunction(eqlFn) ? eqlFn : defaultEqualityFn,
-    customContext = defaultContext,
-  } = opts || (!isFunction(eqlFn) && eqlFn) || {};
+export const createUseSelector = customContext => (
+  selector,
+  equalityFn = defaultEqualityFn,
+) => {
   const forceUpdate = useForceUpdate();
   const { state, subscribe } = useContext(customContext);
   const selected = selector(state);
@@ -49,3 +47,5 @@ export const useSelector = (selector, eqlFn, opts) => {
   }, [subscribe, forceUpdate]);
   return selected;
 };
+
+export const useSelector = createUseSelector(defaultContext);

--- a/src/useTrackedState.js
+++ b/src/useTrackedState.js
@@ -11,12 +11,9 @@ import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
 import { createDeepProxy, isDeepChanged } from './deepProxy';
 
-import { useDispatch } from './useDispatch';
+import { createUseDispatch } from './useDispatch';
 
-export const useTrackedState = (opts = {}) => {
-  const {
-    customContext = defaultContext,
-  } = opts;
+export const createUseTrackedState = customContext => (opts = {}) => {
   const forceUpdate = useForceUpdate();
   const { state, subscribe } = useContext(customContext);
   const affected = new WeakMap();
@@ -57,8 +54,15 @@ export const useTrackedState = (opts = {}) => {
   return createDeepProxy(state, affected, proxyCache.current);
 };
 
-export const useTracked = (opts = {}) => {
-  const state = useTrackedState(opts);
-  const dispatch = useDispatch(opts);
-  return useMemo(() => [state, dispatch], [state, dispatch]);
+export const createUseTracked = (customContext) => {
+  const useTrackedState = createUseTrackedState(customContext);
+  const useDispatch = createUseDispatch(customContext);
+  return (opts) => {
+    const state = useTrackedState(opts);
+    const dispatch = useDispatch();
+    return useMemo(() => [state, dispatch], [state, dispatch]);
+  };
 };
+
+export const useTrackedState = createUseTrackedState(defaultContext);
+export const useTracked = createUseTracked(defaultContext);


### PR DESCRIPTION
Historically, this library is designed to have the same hooks API as reactive-react-redux. The createContainer was added afterward.

Now, I consider that exposing customContext in props may mislead the usage (as well as the useValue prop), and recommend createContainer more than default context.