### PR TITLE
trackMemo to track a whole object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- A new API trackMemo as an escape hatch for React.memo (#22)
 
 ## [0.9.0] - 2019-10-05
 ### Changed

--- a/README.md
+++ b/README.md
@@ -126,6 +126,58 @@ to force update when a component needs to re-render.
 
 [Recipes Docs](./website/docs/recipes.md)
 
+## Caveats
+
+Proxy and state usage tracking may not work 100% as expected.
+There are some limitations and workarounds.
+
+### Proxied states are referentially equal only in per-hook basis
+
+```javascript
+const state1 = useTrackedState();
+const state2 = useTrackedState();
+// state1 and state2 is not referentially equal
+// even if the underlying redux state is referentially equal.
+```
+
+You should use `useTrackedState` only once in a component.
+
+### An object referential change doesn't trigger re-render if an property of the object is accessed in previous render
+
+```javascript
+const state = useTrackedState();
+const { foo } = state;
+return <Child key={foo.id} foo={foo} />;
+
+const Child = React.memo(({ foo }) => {
+  // ...
+};
+// if foo doesn't change, Child won't render, so foo.id is only marked as used.
+// it won't trigger Child to re-render even if foo is changed.
+```
+
+You need to explicitly notify an object as used in a memoized component.
+
+```javascript
+import { trackMemo } from 'react-tracked';
+
+const Child = React.memo(({ foo }) => {
+  trackMemo(foo);
+  // ...
+};
+```
+
+### Proxied state shouldn't be used outside of render
+
+```javascript
+const state = useTrackedState();
+const dispatch = useUpdate();
+dispatch({ type: 'FOO', value: state.foo }); // This may lead unexpected behavior if state.foo is an object
+dispatch({ type: 'FOO', value: state.fooStr }); // This is OK if state.fooStr is a string
+```
+
+You should use primitive values for `dispatch`, `setState` and others.
+
 ## Examples
 
 The [examples](examples) folder contains working examples.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ You can also try them in codesandbox.io:
 [06](https://codesandbox.io/s/github/dai-shi/react-tracked/tree/master/examples/06_customhook)
 [07](https://codesandbox.io/s/github/dai-shi/react-tracked/tree/master/examples/07_todolist)
 [08](https://codesandbox.io/s/github/dai-shi/react-tracked/tree/master/examples/08_comparison)
+[09](https://codesandbox.io/s/github/dai-shi/react-tracked/tree/master/examples/09_reactmemo)
 
 ## Related projects
 

--- a/__tests__/11_track_memo.js
+++ b/__tests__/11_track_memo.js
@@ -1,0 +1,77 @@
+import { createDeepProxy, isDeepChanged, trackMemo } from '../src/deepProxy';
+
+const noop = () => {};
+
+describe('object tracking', () => {
+  it('should fail without trackMemo', () => {
+    const proxyCache = new WeakMap();
+    const s1 = { a: { b: 1, c: 2 } };
+    const a1 = new WeakMap();
+    const p1 = createDeepProxy(s1, a1, proxyCache);
+    noop(p1.a.b);
+    expect(isDeepChanged(s1, { a: s1.a }, a1)).toBe(false);
+    expect(isDeepChanged(s1, { a: { b: 3, c: 2 } }, a1)).toBe(true);
+    expect(isDeepChanged(s1, { a: { b: 1, c: 3 } }, a1)).not.toBe(true);
+  });
+
+  it('should work with trackMemo', () => {
+    const proxyCache = new WeakMap();
+    const s1 = { a: { b: 1, c: 2 } };
+    const a1 = new WeakMap();
+    const p1 = createDeepProxy(s1, a1, proxyCache);
+    noop(p1.a.b);
+    trackMemo(p1.a);
+    expect(isDeepChanged(s1, { a: s1.a }, a1)).toBe(false);
+    expect(isDeepChanged(s1, { a: { b: 3, c: 2 } }, a1)).toBe(true);
+    expect(isDeepChanged(s1, { a: { b: 1, c: 3 } }, a1)).toBe(true);
+  });
+
+  it('should work with trackMemo in advance', () => {
+    const proxyCache = new WeakMap();
+    const s1 = { a: { b: 1, c: 2 } };
+    const a1 = new WeakMap();
+    const p1 = createDeepProxy(s1, a1, proxyCache);
+    trackMemo(p1.a);
+    noop(p1.a.b);
+    expect(isDeepChanged(s1, { a: s1.a }, a1)).toBe(false);
+    expect(isDeepChanged(s1, { a: { b: 3, c: 2 } }, a1)).toBe(true);
+    expect(isDeepChanged(s1, { a: { b: 1, c: 3 } }, a1)).toBe(true);
+  });
+});
+
+describe('object tracking two level deep', () => {
+  it('should fail without trackMemo', () => {
+    const proxyCache = new WeakMap();
+    const s1 = { x: { a: { b: 1, c: 2 } } };
+    const a1 = new WeakMap();
+    const p1 = createDeepProxy(s1, a1, proxyCache);
+    noop(p1.x.a.b);
+    expect(isDeepChanged(s1, { x: { a: s1.x.a } }, a1)).toBe(false);
+    expect(isDeepChanged(s1, { x: { a: { b: 3, c: 2 } } }, a1)).toBe(true);
+    expect(isDeepChanged(s1, { x: { a: { b: 1, c: 3 } } }, a1)).not.toBe(true);
+  });
+
+  it('should work with trackMemo', () => {
+    const proxyCache = new WeakMap();
+    const s1 = { x: { a: { b: 1, c: 2 } } };
+    const a1 = new WeakMap();
+    const p1 = createDeepProxy(s1, a1, proxyCache);
+    noop(p1.x.a.b);
+    trackMemo(p1.x.a);
+    expect(isDeepChanged(s1, { x: { a: s1.x.a } }, a1)).toBe(false);
+    expect(isDeepChanged(s1, { x: { a: { b: 3, c: 2 } } }, a1)).toBe(true);
+    expect(isDeepChanged(s1, { x: { a: { b: 1, c: 3 } } }, a1)).toBe(true);
+  });
+
+  it('should work with trackMemo in advance', () => {
+    const proxyCache = new WeakMap();
+    const s1 = { x: { a: { b: 1, c: 2 } } };
+    const a1 = new WeakMap();
+    const p1 = createDeepProxy(s1, a1, proxyCache);
+    trackMemo(p1.x.a);
+    noop(p1.x.a.b);
+    expect(isDeepChanged(s1, { x: { a: s1.x.a } }, a1)).toBe(false);
+    expect(isDeepChanged(s1, { x: { a: { b: 3, c: 2 } } }, a1)).toBe(true);
+    expect(isDeepChanged(s1, { x: { a: { b: 1, c: 3 } } }, a1)).toBe(true);
+  });
+});

--- a/examples/09_reactmemo/package.json
+++ b/examples/09_reactmemo/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "react-tracked-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@types/react": "^16.7.6",
+    "@types/react-dom": "^16.0.9",
+    "immer": "^3.1.3",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-tracked": "latest",
+    "react-scripts": "^2.1.1",
+    "typescript": "^3.1.6"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/09_reactmemo/package.json
+++ b/examples/09_reactmemo/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@types/react": "^16.7.6",
     "@types/react-dom": "^16.0.9",
-    "immer": "^3.1.3",
     "react": "latest",
     "react-dom": "latest",
     "react-tracked": "latest",

--- a/examples/09_reactmemo/public/index.html
+++ b/examples/09_reactmemo/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>react-tracked example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/09_reactmemo/src/App.tsx
+++ b/examples/09_reactmemo/src/App.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import { Provider } from './store';
+import TodoList from './TodoList';
+
+const App: React.FC = () => (
+  <Provider>
+    <TodoList />
+  </Provider>
+);
+
+export default App;

--- a/examples/09_reactmemo/src/TodoItem.tsx
+++ b/examples/09_reactmemo/src/TodoItem.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { trackMemo } from 'react-tracked';
+
+import { useDispatch, TodoType } from './store';
+
+type Props = {
+  todo: TodoType;
+};
+
+const TodoItem: React.FC<Props> = ({ todo }) => {
+  trackMemo(todo);
+  const dispatch = useDispatch();
+  return (
+    <li>
+      {Math.random()}
+      <input
+        type="checkbox"
+        onChange={() => dispatch({ type: 'TOGGLE_TODO', id: todo.id })}
+      />
+      <span
+        style={{
+          textDecoration: todo.completed ? 'line-through' : 'none',
+        }}
+      >
+        {todo.title}
+      </span>
+    </li>
+  );
+};
+
+export default React.memo(TodoItem);

--- a/examples/09_reactmemo/src/TodoList.tsx
+++ b/examples/09_reactmemo/src/TodoList.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { useTrackedState } from './store';
+import TodoItem from './TodoItem';
+
+const TodoList: React.FC = () => {
+  const state = useTrackedState();
+  const { todos } = state;
+  return (
+    <ul>
+      {todos.map(todo => (
+        <TodoItem key={todo.id} todo={todo} />
+      ))}
+    </ul>
+  );
+};
+
+export default TodoList;

--- a/examples/09_reactmemo/src/index.ts
+++ b/examples/09_reactmemo/src/index.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  unstable_createRoot as createRoot,
+} from 'react-dom';
+
+import App from './App';
+
+const ele = document.getElementById('app');
+if (!ele) throw new Error('no app');
+createRoot(ele).render(React.createElement(App));

--- a/examples/09_reactmemo/src/store.ts
+++ b/examples/09_reactmemo/src/store.ts
@@ -1,0 +1,70 @@
+import { useReducer } from 'react';
+import { createContainer } from 'react-tracked';
+
+export type TodoType = {
+  id: number;
+  title: string;
+  completed: boolean;
+};
+
+type State = {
+  todos: TodoType[];
+};
+
+type Action =
+  | { type: 'ADD_TODO'; title: string }
+  | { type: 'DELETE_TODO'; id: number }
+  | { type: 'CHANGE_TODO'; id: number; title: string }
+  | { type: 'TOGGLE_TODO'; id: number };
+
+const initialState: State = {
+  todos: [
+    { id: 1, title: 'Wash dishes', completed: false },
+    { id: 2, title: 'Study JS', completed: false },
+    { id: 3, title: 'Buy ticket', completed: false },
+  ],
+};
+
+let nextId = 4;
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'ADD_TODO':
+      return {
+        ...state,
+        todos: [
+          ...state.todos,
+          { id: nextId++, title: action.title, completed: false },
+        ],
+      };
+    case 'DELETE_TODO':
+      return {
+        ...state,
+        todos: state.todos.filter(todo => todo.id !== action.id),
+      };
+    case 'CHANGE_TODO':
+      return {
+        ...state,
+        todos: state.todos.map(todo => (
+          todo.id === action.id ? { ...todo, title: action.title } : todo
+        )),
+      };
+    case 'TOGGLE_TODO':
+      return {
+        ...state,
+        todos: state.todos.map(todo => (
+          todo.id === action.id ? { ...todo, completed: !todo.completed } : todo
+        )),
+      };
+    default:
+      return state;
+  }
+};
+
+const useValue = () => useReducer(reducer, initialState);
+
+export const {
+  Provider,
+  useTrackedState,
+  useUpdate: useDispatch,
+} = createContainer(useValue);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "examples:container": "DIR=05_container webpack-dev-server",
     "examples:customhook": "DIR=06_customhook EXT=js webpack-dev-server",
     "examples:todolist": "DIR=07_todolist webpack-dev-server",
-    "examples:comparison": "DIR=08_comparison webpack-dev-server"
+    "examples:comparison": "DIR=08_comparison webpack-dev-server",
+    "examples:reactmemo": "DIR=09_reactmemo webpack-dev-server"
   },
   "keywords": [
     "react",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,3 +13,7 @@ export const createContainer: <State, Update, Props>(
   useUpdate: () => Update;
   useSelector: <V>(selector: (state: State) => V, equalityFn?: EqlFn<V>) => V;
 };
+
+// deep proxy utils
+
+export const trackMemo: (obj: unknown) => void;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export { createContainer } from './createContainer';
+export { trackMemo } from './deepProxy';


### PR DESCRIPTION
This should close #21 

The only escape hatch I could think of is to introduce a function to explicitly specify props used in React.memo.

- [x] code
- [x] test
- [x] readme
- [x] example