### PR TITLE
no anonymous hook names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Fix anonymous hook names
 
 ## [1.1.1] - 2020-02-26
 ### Changed

--- a/src/createUseSelector.js
+++ b/src/createUseSelector.js
@@ -17,44 +17,47 @@ const SELECTED_PROPERTY = 'l';
 
 const defaultEqualityFn = (a, b) => a === b;
 
-export const createUseSelector = (context) => (
-  selector,
-  equalityFn = defaultEqualityFn,
-) => {
-  const [, forceUpdate] = useReducer((c) => c + 1, 0);
-  const {
-    [STATE_CONTEXT_PROPERTY]: state,
-    [SUBSCRIBE_CONTEXT_PROPERTY]: subscribe,
-  } = useContext(context);
-  const selected = selector(state);
-  const ref = useRef();
-  useIsomorphicLayoutEffect(() => {
-    ref.current = {
-      [EQUALITY_FN_PROPERTY]: equalityFn,
-      [SELECTOR_PROPERTY]: selector,
-      [STATE_PROPERTY]: state,
-      [SELECTED_PROPERTY]: selected,
-    };
-  });
-  useIsomorphicLayoutEffect(() => {
-    const callback = (nextState) => {
-      try {
-        const refCurrent = ref.current;
-        if (refCurrent[STATE_PROPERTY] === nextState
-          || refCurrent[EQUALITY_FN_PROPERTY](
-            refCurrent[SELECTED_PROPERTY],
-            refCurrent[SELECTOR_PROPERTY](nextState),
-          )) {
-          // not changed
-          return;
+export const createUseSelector = (context) => {
+  const useSelector = (
+    selector,
+    equalityFn = defaultEqualityFn,
+  ) => {
+    const [, forceUpdate] = useReducer((c) => c + 1, 0);
+    const {
+      [STATE_CONTEXT_PROPERTY]: state,
+      [SUBSCRIBE_CONTEXT_PROPERTY]: subscribe,
+    } = useContext(context);
+    const selected = selector(state);
+    const ref = useRef();
+    useIsomorphicLayoutEffect(() => {
+      ref.current = {
+        [EQUALITY_FN_PROPERTY]: equalityFn,
+        [SELECTOR_PROPERTY]: selector,
+        [STATE_PROPERTY]: state,
+        [SELECTED_PROPERTY]: selected,
+      };
+    });
+    useIsomorphicLayoutEffect(() => {
+      const callback = (nextState) => {
+        try {
+          const refCurrent = ref.current;
+          if (refCurrent[STATE_PROPERTY] === nextState
+            || refCurrent[EQUALITY_FN_PROPERTY](
+              refCurrent[SELECTED_PROPERTY],
+              refCurrent[SELECTOR_PROPERTY](nextState),
+            )) {
+            // not changed
+            return;
+          }
+        } catch (e) {
+          // ignored (stale props or some other reason)
         }
-      } catch (e) {
-        // ignored (stale props or some other reason)
-      }
-      forceUpdate();
-    };
-    const unsubscribe = subscribe(callback);
-    return unsubscribe;
-  }, [subscribe]);
-  return selected;
+        forceUpdate();
+      };
+      const unsubscribe = subscribe(callback);
+      return unsubscribe;
+    }, [subscribe]);
+    return selected;
+  };
+  return useSelector;
 };

--- a/src/createUseTrackedState.js
+++ b/src/createUseTrackedState.js
@@ -31,61 +31,65 @@ const AFFECTED_PROPERTY = 'a';
 const CACHE_PROPERTY = 'c';
 const DEEP_PROXY_MODE_PROPERTY = 'd';
 
-export const createUseTrackedState = (context) => (opts = {}) => {
-  const [, forceUpdate] = useReducer((c) => c + 1, 0);
-  const {
-    [STATE_CONTEXT_PROPERTY]: state,
-    [SUBSCRIBE_CONTEXT_PROPERTY]: subscribe,
-  } = useContext(context);
-  const affected = new WeakMap();
-  const lastTracked = useRef();
-  useIsomorphicLayoutEffect(() => {
-    lastTracked.current = {
-      [STATE_PROPERTY]: state,
-      [AFFECTED_PROPERTY]: affected,
-      [CACHE_PROPERTY]: new WeakMap(),
-      /* eslint-disable no-nested-ternary, indent */
-      [DEEP_PROXY_MODE_PROPERTY]:
+export const createUseTrackedState = (context) => {
+  const useTrackedState = (opts = {}) => {
+    const [, forceUpdate] = useReducer((c) => c + 1, 0);
+    const {
+      [STATE_CONTEXT_PROPERTY]: state,
+      [SUBSCRIBE_CONTEXT_PROPERTY]: subscribe,
+    } = useContext(context);
+    const affected = new WeakMap();
+    const lastTracked = useRef();
+    useIsomorphicLayoutEffect(() => {
+      lastTracked.current = {
+        [STATE_PROPERTY]: state,
+        [AFFECTED_PROPERTY]: affected,
+        [CACHE_PROPERTY]: new WeakMap(),
+        /* eslint-disable no-nested-ternary, indent */
+        [DEEP_PROXY_MODE_PROPERTY]:
         opts.unstable_forceUpdateForStateChange ? MODE_ALWAYS_ASSUME_CHANGED_IF_UNAFFECTED
-      : opts.unstable_ignoreIntermediateObjectUsage ? MODE_ALWAYS_ASSUME_UNCHANGED_IF_UNAFFECTED
-      : opts.unstable_ignoreStateEquality ? MODE_MUTABLE_ROOT_STATE
-      : /* default */ MODE_DEFAULT,
-      /* eslint-enable no-nested-ternary, indent */
-    };
-  });
-  useIsomorphicLayoutEffect(() => {
-    const callback = (nextState) => {
-      try {
-        const lastTrackedCurrent = lastTracked.current;
-        if (lastTrackedCurrent[STATE_PROPERTY] === nextState
-          || !isDeepChanged(
-            lastTrackedCurrent[STATE_PROPERTY],
-            nextState,
-            lastTrackedCurrent[AFFECTED_PROPERTY],
-            lastTrackedCurrent[CACHE_PROPERTY],
-            lastTrackedCurrent[DEEP_PROXY_MODE_PROPERTY],
-          )) {
-          // not changed
-          return;
+        : opts.unstable_ignoreIntermediateObjectUsage ? MODE_ALWAYS_ASSUME_UNCHANGED_IF_UNAFFECTED
+        : opts.unstable_ignoreStateEquality ? MODE_MUTABLE_ROOT_STATE
+        : /* default */ MODE_DEFAULT,
+        /* eslint-enable no-nested-ternary, indent */
+      };
+    });
+    useIsomorphicLayoutEffect(() => {
+      const callback = (nextState) => {
+        try {
+          const lastTrackedCurrent = lastTracked.current;
+          if (lastTrackedCurrent[STATE_PROPERTY] === nextState
+            || !isDeepChanged(
+              lastTrackedCurrent[STATE_PROPERTY],
+              nextState,
+              lastTrackedCurrent[AFFECTED_PROPERTY],
+              lastTrackedCurrent[CACHE_PROPERTY],
+              lastTrackedCurrent[DEEP_PROXY_MODE_PROPERTY],
+            )) {
+            // not changed
+            return;
+          }
+        } catch (e) {
+          // ignored (thrown promise or some other reason)
         }
-      } catch (e) {
-        // ignored (thrown promise or some other reason)
-      }
-      forceUpdate();
-    };
-    const unsubscribe = subscribe(callback);
-    return unsubscribe;
-  }, [subscribe]);
-  const proxyCache = useRef(new WeakMap()); // per-hook proxyCache
-  return createDeepProxy(state, affected, proxyCache.current);
+        forceUpdate();
+      };
+      const unsubscribe = subscribe(callback);
+      return unsubscribe;
+    }, [subscribe]);
+    const proxyCache = useRef(new WeakMap()); // per-hook proxyCache
+    return createDeepProxy(state, affected, proxyCache.current);
+  };
+  return useTrackedState;
 };
 
 export const createUseTracked = (context) => {
   const useTrackedState = createUseTrackedState(context);
   const useUpdate = createUseUpdate(context);
-  return (opts) => {
+  const useTracked = (opts) => {
     const state = useTrackedState(opts);
     const update = useUpdate();
     return useMemo(() => [state, update], [state, update]);
   };
+  return useTracked;
 };

--- a/src/createUseUpdate.js
+++ b/src/createUseUpdate.js
@@ -2,7 +2,10 @@ import { useContext } from 'react';
 
 import { UPDATE_CONTEXT_PROPERTY } from './createProvider';
 
-export const createUseUpdate = (context) => () => {
-  const { [UPDATE_CONTEXT_PROPERTY]: update } = useContext(context);
-  return update;
+export const createUseUpdate = (context) => {
+  const useUpdate = () => {
+    const { [UPDATE_CONTEXT_PROPERTY]: update } = useContext(context);
+    return update;
+  };
+  return useUpdate;
 };


### PR DESCRIPTION
Previously, hooks are anonymous functions and so displayed in React DevTools. This fixes it.