### PR TITLE
export special memo instead of trackMemo

### DIFF
--- a/examples/09_reactmemo/src/TodoItem.tsx
+++ b/examples/09_reactmemo/src/TodoItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { trackMemo } from 'react-tracked';
+import { memo } from 'react-tracked';
 
 import { useDispatch, TodoType } from './store';
 
@@ -10,7 +10,6 @@ type Props = {
 let numRendered = 0;
 
 const TodoItem: React.FC<Props> = ({ todo }) => {
-  trackMemo(todo);
   const dispatch = useDispatch();
   return (
     <li>
@@ -31,4 +30,5 @@ const TodoItem: React.FC<Props> = ({ todo }) => {
   );
 };
 
-export default React.memo(TodoItem);
+// export default React.memo(TodoItem); // Instead of React.memo
+export default memo(TodoItem); // Use custom memo

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,13 +17,14 @@ export const createContainer: <State, Update, Props>(
 // deep proxy utils
 
 /**
- * If `obj` is a proxy, it will mark the entire object as used.
- * Otherwise, it does nothing.
- */
-export const trackMemo: (obj: unknown) => void;
-
-/**
  * If `obj` is a proxy, it will return the original object.
  * Otherwise, it will return null.
  */
 export const getUntrackedObject: <T>(obj: T) => T | null;
+
+// special React.memo with tracking suppoort
+
+export function memo<Props>(
+  Component: React.FC<Props>,
+  areEqual?: (prevProps: Props, nextProps: Props) => boolean,
+): React.FC<Props>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { createContainer } from './createContainer';
-export { trackMemo, getUntrackedObject } from './deepProxy';
+export { getUntrackedObject } from './deepProxy';
+export { memo } from './memo';

--- a/src/memo.js
+++ b/src/memo.js
@@ -1,0 +1,11 @@
+import { createElement, memo as reactMemo } from 'react';
+
+import { trackMemo } from './deepProxy';
+
+export const memo = (Component, areEqual) => {
+  const WrappedComponent = (props) => {
+    Object.values(props).forEach(trackMemo);
+    return createElement(Component, props);
+  };
+  return reactMemo(WrappedComponent, areEqual);
+};

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -100,21 +100,19 @@ const Component = () => {
 };
 ```
 
-## trackMemo
+## memo
 
-There is a tiny function exported from the library.
+There is a utility function exported from the library.
 
-This is used to explicitly mark a prop object as used
-in a memoized component. Otherwise, usage tracking may not
+This should be used instead of `React.memo` if props
+include objects being tracked. Otherwise, usage tracking may not
 work correctly because a memoized component doesn't always render
 when a parent component renders.
 
 ```javascript
-import { trackMemo } from 'react-tracked';
+import { memo } from 'react-tracked';
 
-const ChildComponent = React.memo(({ num1, str1, obj1, obj2 }) => {
-  trackMemo(obj1);
-  trackMemo(obj2);
+const ChildComponent = memo(({ num1, str1, obj1, obj2 }) => {
   // ...
 });
 ```

--- a/website/docs/caveats.md
+++ b/website/docs/caveats.md
@@ -33,13 +33,12 @@ const Child = React.memo(({ foo }) => {
 // it won't trigger Child to re-render even if foo is changed.
 ```
 
-You need to explicitly notify an object as used in a memoized component.
+You need to use a special `memo` provided by this library.
 
 ```javascript
-import { trackMemo } from 'react-tracked';
+import { memo } from 'react-tracked';
 
-const Child = React.memo(({ foo }) => {
-  trackMemo(foo);
+const Child = memo(({ foo }) => {
   // ...
 };
 ```

--- a/website/docs/tutorial-02.md
+++ b/website/docs/tutorial-02.md
@@ -195,7 +195,7 @@ This is the TodoItem component.
 We prefer primitive props for memoized components.
 
 If you want to use object props for memoized components,
-you need to notify the objects by [trackMemo](/docs/api#trackmemo).
+you need to use a special [memo](/docs/api#memo) instead of `React.memo`.
 See [example/09](https://github.com/dai-shi/react-tracked/tree/master/examples/09_reactmemo) for the usage.
 
 ## src/NewTodo.js

--- a/website/docs/tutorial-03.md
+++ b/website/docs/tutorial-03.md
@@ -281,7 +281,7 @@ This is the TodoItem component.
 We prefer primitive props for memoized components.
 
 If you want to use object props for memoized components,
-you need to notify the objects by [trackMemo](/docs/api#trackmemo).
+you need to use a special [memo](/docs/api#memo) instead of `React.memo`.
 See [example/09](https://github.com/dai-shi/react-tracked/tree/master/examples/09_reactmemo) for the usage.
 
 ## src/components/NewTodo.js


### PR DESCRIPTION
This is to follow the same change in https://github.com/dai-shi/reactive-react-redux/pull/49.

This is technically a breaking change, but we release it as a minor update.