### PR TITLE
fix: render from parent

### DIFF
--- a/__tests__/e2e/14_dynamic.ts
+++ b/__tests__/e2e/14_dynamic.ts
@@ -1,0 +1,55 @@
+/* global page */
+
+jest.setTimeout(15 * 1000);
+
+describe('02_typescript', () => {
+  const port = process.env.PORT || '8080';
+
+  it('should work with recorded events', async () => {
+    await page.goto(`http://localhost:${port}/`);
+
+    await page.waitForSelector('body > #app > div:nth-child(2) > div > button:nth-child(2)');
+    await page.click('body > #app > div:nth-child(2) > div > button:nth-child(2)');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.waitForSelector('body > #app > div:nth-child(2) > div > input');
+    await page.click('body > #app > div:nth-child(2) > div > input');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.type('body > #app > div:nth-child(2) > div > input', '1');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.waitForSelector('body > #app > div:nth-child(2) > div > button:nth-child(3)');
+    await page.click('body > #app > div:nth-child(2) > div > button:nth-child(3)');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.waitForSelector('body > #app > div:nth-child(3) > div > input');
+    await page.click('body > #app > div:nth-child(3) > div > input');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.type('body > #app > div:nth-child(3) > div > input', '1');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.waitForSelector('body > #app > div:nth-child(5) > div:nth-child(1) > input');
+    await page.click('body > #app > div:nth-child(5) > div:nth-child(1) > input');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.type('body > #app > div:nth-child(5) > div:nth-child(1) > input', 'a');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.waitForSelector('body > #app > div:nth-child(5) > div > button');
+    await page.click('body > #app > div:nth-child(5) > div > button');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.waitForSelector('body > #app > div:nth-child(5) > div:nth-child(1) > input');
+    await page.click('body > #app > div:nth-child(5) > div:nth-child(1) > input');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.type('body > #app > div:nth-child(5) > div:nth-child(1) > input', 'b');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+
+    await page.waitForSelector('body > #app > div:nth-child(6) > div > button');
+    await page.click('body > #app > div:nth-child(6) > div > button');
+    expect(await page.evaluate(() => document.body.innerHTML)).toMatchSnapshot();
+  });
+});

--- a/__tests__/e2e/14_dynamic.ts
+++ b/__tests__/e2e/14_dynamic.ts
@@ -2,7 +2,7 @@
 
 jest.setTimeout(15 * 1000);
 
-describe('02_typescript', () => {
+describe('14_dynamic', () => {
   const port = process.env.PORT || '8080';
 
   it('should work with recorded events', async () => {

--- a/__tests__/e2e/__snapshots__/14_dynamic.ts.snap
+++ b/__tests__/e2e/__snapshots__/14_dynamic.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`02_typescript should work with recorded events 1`] = `
+exports[`14_dynamic should work with recorded events 1`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 10<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -8,7 +8,7 @@ exports[`02_typescript should work with recorded events 1`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 2`] = `
+exports[`14_dynamic should work with recorded events 2`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 10<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -16,7 +16,7 @@ exports[`02_typescript should work with recorded events 2`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 3`] = `
+exports[`14_dynamic should work with recorded events 3`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 14<div><span>Count: 0</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -24,7 +24,7 @@ exports[`02_typescript should work with recorded events 3`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 4`] = `
+exports[`14_dynamic should work with recorded events 4`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -32,7 +32,7 @@ exports[`02_typescript should work with recorded events 4`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 5`] = `
+exports[`14_dynamic should work with recorded events 5`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -40,7 +40,7 @@ exports[`02_typescript should work with recorded events 5`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 6`] = `
+exports[`14_dynamic should work with recorded events 6`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -48,7 +48,7 @@ exports[`02_typescript should work with recorded events 6`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 7`] = `
+exports[`14_dynamic should work with recorded events 7`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -56,7 +56,7 @@ exports[`02_typescript should work with recorded events 7`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 8`] = `
+exports[`14_dynamic should work with recorded events 8`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 22<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -64,7 +64,7 @@ exports[`02_typescript should work with recorded events 8`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 9`] = `
+exports[`14_dynamic should work with recorded events 9`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 26<div>Last Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -72,7 +72,7 @@ exports[`02_typescript should work with recorded events 9`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 10`] = `
+exports[`14_dynamic should work with recorded events 10`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 26<div>Last Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -80,7 +80,7 @@ exports[`02_typescript should work with recorded events 10`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 11`] = `
+exports[`14_dynamic should work with recorded events 11`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 32<div>Last Name:<input value=\\"b\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>
@@ -88,7 +88,7 @@ exports[`02_typescript should work with recorded events 11`] = `
 "
 `;
 
-exports[`02_typescript should work with recorded events 12`] = `
+exports[`14_dynamic should work with recorded events 12`] = `
 "
     <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 32<div>Last Name:<input value=\\"b\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 38<div>Last Name:<input value=\\"b\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
   <script src=\\"/main.js\\"></script>

--- a/__tests__/e2e/__snapshots__/14_dynamic.ts.snap
+++ b/__tests__/e2e/__snapshots__/14_dynamic.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`02_typescript should work with recorded events 1`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 10<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 2`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 10<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 3`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 14<div><span>Count: 0</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 4`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 5`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 12<div><span>Count: 1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"0\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 6`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 7`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 2<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 4<div>First Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 8`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 22<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 9`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 26<div>Last Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 10`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 26<div>Last Name:<input value=\\"\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 11`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 32<div>Last Name:<input value=\\"b\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 24<div>First Name:<input value=\\"a\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;
+
+exports[`02_typescript should work with recorded events 12`] = `
+"
+    <div id=\\"app\\"><h1>Counter</h1><div>numRendered: 20<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><div>numRendered: 26<div><span>Count: -1</span><button type=\\"button\\">+1</button><button type=\\"button\\">-1</button><input value=\\"1\\"></div></div><h1>Person</h1><div>numRendered: 32<div>Last Name:<input value=\\"b\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div><div>numRendered: 38<div>Last Name:<input value=\\"b\\"><button type=\\"button\\">toggle</button></div><div>Age:<input value=\\"0\\"></div></div></div>
+  <script src=\\"/main.js\\"></script>
+
+"
+`;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "e2e-test:11_form": "server-test examples:11_form 8080 'jest --preset jest-puppeteer __tests__/e2e/11_form.ts'",
     "e2e-test:12_async": "server-test examples:12_async 8080 'jest --preset jest-puppeteer __tests__/e2e/12_async.ts'",
     "e2e-test:13_saga": "server-test examples:13_saga 8080 'jest --preset jest-puppeteer __tests__/e2e/13_saga.ts'",
+    "e2e-test:14_dynamic": "server-test examples:14_dynamic 8080 'jest --preset jest-puppeteer __tests__/e2e/14_dynamic.ts'",
     "examples:01_minimal": "DIR=01_minimal EXT=js webpack-dev-server",
     "examples:02_typescript": "DIR=02_typescript webpack-dev-server",
     "examples:03_usestate": "DIR=03_usestate webpack-dev-server",


### PR DESCRIPTION
There's a huge regression in v1.5.0 compared to v1.4.2 and prior to it (those based on changedBits=0).
It failed to re-render when it's triggered by something outside state.

This PR should fix the behavior. (It's unfortunate that we need to rely on useLayoutEffect again.)