### PR TITLE
legacyMode argument for CM workaround

### DIFF
--- a/__tests__/01_basic_spec.tsx
+++ b/__tests__/01_basic_spec.tsx
@@ -19,7 +19,7 @@ describe('basic spec', () => {
       return state;
     };
     const useValue = () => useReducer(reducer, initialState);
-    const { Provider, useTracked } = createContainer(useValue);
+    const { Provider, useTracked } = createContainer(useValue, true);
     const Counter = () => {
       const [state, dispatch] = useTracked();
       return (

--- a/examples/01_minimal/src/index.js
+++ b/examples/01_minimal/src/index.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { createContainer } from 'react-tracked';
 
 const useValue = ({ reducer, initialState }) => useReducer(reducer, initialState);
-const { Provider, useTracked } = createContainer(useValue);
+const { Provider, useTracked } = createContainer(useValue, true);
 
 const initialState = {
   count: 0,

--- a/examples/02_typescript/src/state.ts
+++ b/examples/02_typescript/src/state.ts
@@ -58,4 +58,4 @@ const reducer: Reducer<State, Action> = (state, action) => {
 
 const useValue = () => useReducer(reducer, initialState);
 
-export const { Provider, useTracked } = createContainer(useValue);
+export const { Provider, useTracked } = createContainer(useValue, true);

--- a/examples/03_usestate/src/state.ts
+++ b/examples/03_usestate/src/state.ts
@@ -13,4 +13,4 @@ const initialState = {
 
 const useValue = () => useState(initialState);
 
-export const { Provider, useTracked } = createContainer(useValue);
+export const { Provider, useTracked } = createContainer(useValue, true);

--- a/examples/04_selector/src/state.ts
+++ b/examples/04_selector/src/state.ts
@@ -62,4 +62,4 @@ export const {
   Provider,
   useSelector,
   useUpdate: useDispatch,
-} = createContainer(useValue);
+} = createContainer(useValue, true);

--- a/examples/05_container/src/App.tsx
+++ b/examples/05_container/src/App.tsx
@@ -5,8 +5,8 @@ import { createContainer } from 'react-tracked';
 import { useValue } from './state';
 import Counter from './Counter';
 
-const container1 = createContainer(useValue);
-const container2 = createContainer(useValue);
+const container1 = createContainer(useValue, true);
+const container2 = createContainer(useValue, true);
 
 const App: React.FC = () => (
   <StrictMode>

--- a/examples/06_customhook/src/index.tsx
+++ b/examples/06_customhook/src/index.tsx
@@ -20,7 +20,7 @@ const useValue = () => {
   return [count, setCount] as const;
 };
 
-const { Provider, useTracked } = createContainer(useValue);
+const { Provider, useTracked } = createContainer(useValue, true);
 
 const Counter = () => {
   const [count, setCount] = useTracked();

--- a/examples/07_todolist/src/state.ts
+++ b/examples/07_todolist/src/state.ts
@@ -30,4 +30,4 @@ export const {
   useUpdate: useSetState,
   useTracked,
   useTrackedState,
-} = createContainer(useValue);
+} = createContainer(useValue, true);

--- a/examples/08_comparison/src/ReactTracked.tsx
+++ b/examples/08_comparison/src/ReactTracked.tsx
@@ -28,7 +28,7 @@ const reducer: Reducer<State, Action> = (state, action) => {
   }
 };
 
-const { Provider, useTracked } = createContainer(() => useReducer(reducer, initialState));
+const { Provider, useTracked } = createContainer(() => useReducer(reducer, initialState), true);
 
 const PersonFirstName: React.FC = () => {
   const [state, dispatch] = useTracked();

--- a/examples/09_reactmemo/src/store.ts
+++ b/examples/09_reactmemo/src/store.ts
@@ -67,4 +67,4 @@ export const {
   Provider,
   useTrackedState,
   useUpdate: useDispatch,
-} = createContainer(useValue);
+} = createContainer(useValue, true);

--- a/examples/10_untracked/src/store.ts
+++ b/examples/10_untracked/src/store.ts
@@ -82,7 +82,7 @@ const {
   Provider,
   useTrackedState,
   useUpdate: useDispatch,
-} = createContainer(useValue);
+} = createContainer(useValue, true);
 
 // eslint-disable-next-line arrow-parens
 const untrackDeep = <T>(obj: T) => {

--- a/examples/11_form/src/form.ts
+++ b/examples/11_form/src/form.ts
@@ -23,7 +23,7 @@ const {
   Provider: FormProvider,
   useTrackedState,
   useUpdate: useSetState,
-} = createContainer(() => useState(initialState));
+} = createContainer(() => useState(initialState), true);
 
 const useFormValues = () => {
   const state = useTrackedState();

--- a/examples/12_async/src/store.ts
+++ b/examples/12_async/src/store.ts
@@ -107,4 +107,4 @@ export const {
   Provider,
   useTrackedState,
   useUpdate: useDispatch,
-} = createContainer(useValue);
+} = createContainer(useValue, true);

--- a/examples/13_saga/src/store.ts
+++ b/examples/13_saga/src/store.ts
@@ -125,4 +125,4 @@ export const {
   Provider,
   useTrackedState,
   useUpdate: useDispatch,
-} = createContainer(useValue);
+} = createContainer(useValue, true);

--- a/examples/14_dynamic/src/state.ts
+++ b/examples/14_dynamic/src/state.ts
@@ -66,4 +66,4 @@ const reducer: Reducer<State, Action> = (state, action) => {
 
 const useValue = () => useReducer(reducer, initialState);
 
-export const { Provider, useTracked } = createContainer(useValue);
+export const { Provider, useTracked } = createContainer(useValue, true);

--- a/examples/15_reactmemoref/src/store.ts
+++ b/examples/15_reactmemoref/src/store.ts
@@ -67,4 +67,4 @@ export const {
   Provider,
   useTrackedState,
   useUpdate: useDispatch,
-} = createContainer(useValue);
+} = createContainer(useValue, true);

--- a/src/createContainer.ts
+++ b/src/createContainer.ts
@@ -22,7 +22,7 @@ type AnyFunction = (...args: any[]) => any;
 
 export const createContainer = <State, Update extends AnyFunction, Props>(
   useValue: (props: Props) => readonly [State, Update],
-  legacyMode = false,
+  concurrentMode = false,
 ) => {
   const StateContext = createContext(warningObject as State);
   const UpdateContext = createContextOrig(warningObject as Update);
@@ -41,7 +41,7 @@ export const createContainer = <State, Update extends AnyFunction, Props>(
     opts?: Parameters<typeof useTrackedOrig>[2],
   ) => useTrackedOrig(StateContext, UpdateContext, opts);
 
-  const useUpdate = !legacyMode
+  const useUpdate = concurrentMode
     ? () => useUpdateOrig(StateContext, UpdateContext)
     : () => useContextOrig(UpdateContext);
 

--- a/src/createContainer.ts
+++ b/src/createContainer.ts
@@ -1,11 +1,15 @@
 /* eslint react/destructuring-assignment: off */
 
-import { FC, createContext as createContextOrig, createElement } from 'react';
+import {
+  FC,
+  createContext as createContextOrig,
+  createElement,
+  useContext as useContextOrig,
+} from 'react';
 import { createContext } from 'use-context-selector';
 
 import { useTrackedState as useTrackedStateOrig } from './useTrackedState';
 import { useTracked as useTrackedOrig } from './useTracked';
-import { useUpdate as useUpdateOrig } from './useUpdate';
 import { useSelector as useSelectorOrig } from './useSelector';
 
 const warningObject = new Proxy({}, {
@@ -35,7 +39,7 @@ export const createContainer = <State, Update extends AnyFunction, Props>(
     opts?: Parameters<typeof useTrackedOrig>[2],
   ) => useTrackedOrig(StateContext, UpdateContext, opts);
 
-  const useUpdate = () => useUpdateOrig(StateContext, UpdateContext);
+  const useUpdate = () => useContextOrig(UpdateContext);
 
   const useSelector = <Selected>(
     selector: (state: State) => Selected,

--- a/src/createContainer.ts
+++ b/src/createContainer.ts
@@ -6,11 +6,12 @@ import {
   createElement,
   useContext as useContextOrig,
 } from 'react';
-import { createContext } from 'use-context-selector';
 
+import { createContext } from 'use-context-selector';
 import { useTrackedState as useTrackedStateOrig } from './useTrackedState';
 import { useTracked as useTrackedOrig } from './useTracked';
 import { useSelector as useSelectorOrig } from './useSelector';
+import { useUpdate as useUpdateOrig } from './useUpdate';
 
 const warningObject = new Proxy({}, {
   get() { throw new Error('Please use <Provider>'); },
@@ -21,6 +22,7 @@ type AnyFunction = (...args: any[]) => any;
 
 export const createContainer = <State, Update extends AnyFunction, Props>(
   useValue: (props: Props) => readonly [State, Update],
+  legacyMode = false,
 ) => {
   const StateContext = createContext(warningObject as State);
   const UpdateContext = createContextOrig(warningObject as Update);
@@ -39,7 +41,9 @@ export const createContainer = <State, Update extends AnyFunction, Props>(
     opts?: Parameters<typeof useTrackedOrig>[2],
   ) => useTrackedOrig(StateContext, UpdateContext, opts);
 
-  const useUpdate = () => useContextOrig(UpdateContext);
+  const useUpdate = !legacyMode
+    ? () => useUpdateOrig(StateContext, UpdateContext)
+    : () => useContextOrig(UpdateContext);
 
   const useSelector = <Selected>(
     selector: (state: State) => Selected,

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -43,7 +43,7 @@ which is a hook that returns a tuple `[state, update]`.
 Typically, it's with useReducer and useState,
 but it can be any custom hooks based on them.
 
-The second argument `legacyMode` enables using original context instead of using `useContextUpdate` from `use-context-selector`. It is `false` by default.
+The second argument `concurrentMode` enables using `useContextUpdate` from `use-context-selector` for Concurrent Mode, it's available in experimental branch of React. It is `false` by default.
 
 Note: you can create multiple containers in one app.
 

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -38,10 +38,12 @@ const Component = () => {
 
 ## createContainer
 
-It takes one argument `useValue`,
+It takes two arguments, the first argument `useValue`,
 which is a hook that returns a tuple `[state, update]`.
 Typically, it's with useReducer and useState,
 but it can be any custom hooks based on them.
+
+The second argument `legacyMode` enables using original context instead of using `useContextUpdate` from `use-context-selector`. It is `false` by default.
 
 Note: you can create multiple containers in one app.
 


### PR DESCRIPTION
I added legacyMode argument for CM workaround to enable using React Context without use-context-selector