### PR TITLE
fix: exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,15 @@
   "main": "./dist/index.umd.js",
   "module": "./dist/index.modern.js",
   "types": "./dist/src/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "module": "./dist/index.modern.js",
+      "import": "./dist/index.modern.mjs",
+      "default": "./dist/index.umd.js"
+    }
+  },
   "sideEffects": false,
   "files": [
     "src",
@@ -19,6 +28,7 @@
   ],
   "scripts": {
     "compile": "microbundle build -f modern,umd --no-compress",
+    "postcompile": "cp dist/index.modern.mjs dist/index.modern.js && cp dist/index.modern.mjs.map dist/index.modern.js.map",
     "test": "run-s eslint tsc-test jest e2e-test:*",
     "eslint": "eslint --ext .js,.ts,.tsx --ignore-path .gitignore --ignore-pattern dist .",
     "jest": "jest --preset ts-jest/presets/js-with-ts __tests__/*.tsx",
@@ -68,7 +78,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "proxy-compare": "2.0.1",
+    "proxy-compare": "2.0.2",
     "use-context-selector": "1.3.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7501,10 +7501,10 @@ proxy-addr@~2.0.5:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-compare@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.0.1.tgz#3ae19cf47f64e89bd60fe4f57afd124f733ef64f"
-  integrity sha512-uXj3TtWdR1S2SNwJKbgJB+1FJm9HM3sFzlVc8W6PZvU6ogt9mlkb1WwZQpuKFLkDS6LKY4+FBE18K6ZArphnHA==
+proxy-compare@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.0.2.tgz#343e624d0ec399dfbe575f1d365d4fa042c9fc69"
+  integrity sha512-3qUXJBariEj3eO90M3Rgqq3+/P5Efl0t/dl9g/1uVzIQmO3M+ql4hvNH3mYdu8H+1zcKv07YvL55tsY74jmH1A==
 
 proxy-from-env@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This exports ESM properly for node.

Reference: https://github.com/pmndrs/valtio/issues/210