### PR TITLE
docs(README.md): change 'npm add' to 'npm install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ that provide useSelector-like hooks.
 This package requires some peer dependencies, which you need to install by yourself.
 
 ```bash
-npm add react-tracked react scheduler
+npm install react-tracked react scheduler
 ```
 
 ## Usage


### PR DESCRIPTION
https://docs.npmjs.com/cli/v11/commands/npm-install

```bash
npm install [<package-spec> ...]

aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
```

* In `README.md`, I think using `install` is better than `add` which is alias