### PR TITLE
feat: `useTrackedStore` hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
   },
   "dependencies": {
     "proxy-compare": "^3.0.0",
-    "use-context-selector": "^2.0.0"
+    "use-context-selector": "^2.0.0",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       use-context-selector:
         specifier: ^2.0.0
         version: 2.0.0(react@19.0.0)(scheduler@0.25.0)
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/react@19.0.8)(immer@10.1.1)(react@19.0.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.19.0
@@ -2633,6 +2636,24 @@ packages:
   zod@3.24.1:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adobe/css-tools@4.4.1': {}
@@ -3081,7 +3102,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.26.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -5465,3 +5486,9 @@ snapshots:
       zod: 3.24.1
 
   zod@3.24.1: {}
+
+  zustand@5.0.11(@types/react@19.0.8)(immer@10.1.1)(react@19.0.0):
+    optionalDependencies:
+      '@types/react': 19.0.8
+      immer: 10.1.1
+      react: 19.0.0

--- a/src/useTrackedStore.ts
+++ b/src/useTrackedStore.ts
@@ -1,0 +1,44 @@
+import { useCallback, useMemo } from 'react';
+import { createProxy, isChanged } from 'proxy-compare';
+import type { ExtractState, StoreApi } from 'zustand';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
+
+import { useAffectedDebugValue } from './utils.js';
+
+const condUseAffectedDebugValue = useAffectedDebugValue;
+
+const hasGlobalProcess = typeof process === 'object';
+
+type ReadonlyStoreApi<T> = Pick<
+  StoreApi<T>,
+  'getState' | 'getInitialState' | 'subscribe'
+>;
+
+const identity = <T>(arg: T): T => arg;
+
+export function useTrackedStore<S extends ReadonlyStoreApi<unknown>>(
+  api: S,
+): ExtractState<S>;
+
+export function useTrackedStore<S extends ReadonlyStoreApi<unknown>, U>(
+  api: S,
+  selector: (state: ExtractState<S>) => U,
+): U;
+
+export function useTrackedStore<TState, StateSlice>(
+  api: ReadonlyStoreApi<TState>,
+  selector: (state: TState) => StateSlice = identity as never,
+) {
+  const affected = useMemo(() => new WeakMap(), []);
+  const isTrackedEqual = useCallback(
+    (prev: StateSlice, next: StateSlice): boolean =>
+      !isChanged(prev, next, affected, new WeakMap()),
+    [affected],
+  );
+  const state = useStoreWithEqualityFn(api, selector, isTrackedEqual);
+  if (hasGlobalProcess && process.env.NODE_ENV !== 'production') {
+    condUseAffectedDebugValue(state, affected);
+  }
+  const proxyCache = useMemo(() => new WeakMap(), []);
+  return createProxy(state, affected, proxyCache);
+}


### PR DESCRIPTION
`useTrackedStore` accepts a store instance as its argument and will create a selector that tracks which properties of the returned state were accessed. It only triggers re-renders when accessed properties have changed.

This hook was created because the `createTrackedSelector` API is not possible to use with store instances that are not static (e.g. passed down through the context).

Things to consider:

- `useStoreWithEqualityFn` calls `useDebugValue`. I don't know how that affects tracking of the properties. I assume it's OK because the tracking proxy is created after the call to `useStoreWithEqualityFn`.
- instead of providing a fresh `WeakMap` cache to `isChanged` on every invocation, could we not use a cache that persists across invocations?

Questions:
- I based some of the implementation off `createTrackedSelector`, why does it not use the `targetCache` argument of `createProxy`?